### PR TITLE
Fix: livecontainer 等自签环境打开闪退

### DIFF
--- a/Clash Dash/Utils/CloudKitManager.swift
+++ b/Clash Dash/Utils/CloudKitManager.swift
@@ -10,22 +10,8 @@ class CloudKitManager: ObservableObject {
     // 快路径启发式：识别侧载环境。LiveContainer 将 guest app 放在 Documents/Applications
     // 目录下，该环境不授予 iCloud 权限，访问 CloudKit/ubiquity API 会直接崩溃（SIGTRAP），
     // 因此必须在不触碰任何崩溃 API 的前提下提前拦截
-    private var isSideLoadedEnvironment: Bool {
+    var isSideLoadedEnvironment: Bool {
         Bundle.main.bundleURL.path.contains("/Documents/Applications/")
-    }
-    
-    // 是否可用 iCloud：路径启发式快路径 + accountStatus() 纵深防御。
-    // 快路径保证侧载环境（如 LiveContainer）不触碰 CloudKit API；其余环境再通过
-    // do/catch 包裹的真实账号状态探测确认，任何异常或非可用状态都视为不可用
-    func isICloudAvailable() async -> Bool {
-        guard !isSideLoadedEnvironment else { return false }
-        do {
-            let status = try await container.accountStatus()
-            return status == .available
-        } catch {
-            logger.error("iCloud 可用性探测失败: \(error.localizedDescription)")
-            return false
-        }
     }
     
     // 懒加载容器，避免在无 iCloud entitlement（如 LiveContainer）时初始化即崩溃
@@ -106,15 +92,15 @@ class CloudKitManager: ObservableObject {
     }
     
     func checkICloudStatus() async {
-        // 先检查 iCloud 是否可用（侧载环境快路径 + accountStatus 纵深防御），
-        // 避免无 entitlement 时访问 CloudKit 崩溃
-        guard await isICloudAvailable() else {
+        // 快路径：侧载环境（如 LiveContainer）直接判定不可用，避免触碰崩溃 API
+        guard !isSideLoadedEnvironment else {
             await MainActor.run {
                 iCloudStatus = "iCloud 不可用"
                 logger.warning("iCloud 不可用：未登录或缺少 iCloud 权限")
             }
             return
         }
+        // 纵深防御：单次真实探测账号状态，do/catch 兜底，异常一律视为不可用
         do {
             let status = try await container.accountStatus()
             await MainActor.run {

--- a/Clash Dash/Utils/CloudKitManager.swift
+++ b/Clash Dash/Utils/CloudKitManager.swift
@@ -6,7 +6,30 @@ private let logger = LogManager.shared
 
 class CloudKitManager: ObservableObject {
     static let shared = CloudKitManager()
-    private let container = CKContainer.default()
+    
+    // 快路径启发式：识别侧载环境。LiveContainer 将 guest app 放在 Documents/Applications
+    // 目录下，该环境不授予 iCloud 权限，访问 CloudKit/ubiquity API 会直接崩溃（SIGTRAP），
+    // 因此必须在不触碰任何崩溃 API 的前提下提前拦截
+    private var isSideLoadedEnvironment: Bool {
+        Bundle.main.bundleURL.path.contains("/Documents/Applications/")
+    }
+    
+    // 是否可用 iCloud：路径启发式快路径 + accountStatus() 纵深防御。
+    // 快路径保证侧载环境（如 LiveContainer）不触碰 CloudKit API；其余环境再通过
+    // do/catch 包裹的真实账号状态探测确认，任何异常或非可用状态都视为不可用
+    func isICloudAvailable() async -> Bool {
+        guard !isSideLoadedEnvironment else { return false }
+        do {
+            let status = try await container.accountStatus()
+            return status == .available
+        } catch {
+            logger.error("iCloud 可用性探测失败: \(error.localizedDescription)")
+            return false
+        }
+    }
+    
+    // 懒加载容器，避免在无 iCloud entitlement（如 LiveContainer）时初始化即崩溃
+    private lazy var container: CKContainer = CKContainer.default()
     private let defaults = UserDefaults.standard
     private let recordType = "AppData"
     
@@ -79,12 +102,19 @@ class CloudKitManager: ObservableObject {
         syncGlobalSettings = defaults.bool(forKey: "syncGlobalSettings")
         syncServers = defaults.bool(forKey: "syncServers")
         syncAppearance = defaults.bool(forKey: "syncAppearance")
-        Task {
-            await checkICloudStatus()
-        }
+        // 不在初始化时访问 CloudKit，避免无 iCloud entitlement 时崩溃
     }
     
-    private func checkICloudStatus() async {
+    func checkICloudStatus() async {
+        // 先检查 iCloud 是否可用（侧载环境快路径 + accountStatus 纵深防御），
+        // 避免无 entitlement 时访问 CloudKit 崩溃
+        guard await isICloudAvailable() else {
+            await MainActor.run {
+                iCloudStatus = "iCloud 不可用"
+                logger.warning("iCloud 不可用：未登录或缺少 iCloud 权限")
+            }
+            return
+        }
         do {
             let status = try await container.accountStatus()
             await MainActor.run {

--- a/Clash Dash/Views/Settings/GlobalSettingsView.swift
+++ b/Clash Dash/Views/Settings/GlobalSettingsView.swift
@@ -112,9 +112,28 @@ struct GlobalSettingsView: View {
     @AppStorage("allowManualURLTestGroupSwitch") private var allowManualURLTestGroupSwitch = false
     @AppStorage("serverStatusTimeout") private var serverStatusTimeout = 2.0  // 默认2秒
     @State private var showClearCacheAlert = false
-    @State private var showSyncErrorAlert = false
-    @State private var syncErrorMessage = ""
-    @StateObject private var cloudKitManager = CloudKitManager.shared
+    @State private var cloudKitManager: CloudKitManager?
+    @State private var showCloudSyncUnavailableAlert = false
+    
+    /// 防呆：环境不支持 iCloud 时阻止开启同步，并提示用户
+    private var cloudSyncBinding: Binding<Bool> {
+        Binding(
+            get: { enableCloudSync },
+            set: { newValue in
+                guard newValue else {
+                    enableCloudSync = false
+                    return
+                }
+                Task {
+                    if await CloudKitManager.shared.isICloudAvailable() {
+                        enableCloudSync = true
+                    } else {
+                        showCloudSyncUnavailableAlert = true
+                    }
+                }
+            }
+        )
+    }
     
     var body: some View {
         Form {
@@ -258,93 +277,21 @@ struct GlobalSettingsView: View {
                 SectionHeader(title: "缓存管理", systemImage: "internaldrive")
             }
             
-            Section {
-                SettingToggleRow(
-                    title: "启用 iCloud 同步",
-                    subtitle: "同步服务器配置、全局设置和外观设置到 iCloud",
-                    isOn: $enableCloudSync
+            if enableCloudSync, let cloudKitManager = cloudKitManager {
+                // 开启同步后显示完整 Section（含上次同步时间页脚，随同步结果实时刷新）
+                ICloudSyncSection(
+                    cloudKitManager: cloudKitManager,
+                    cloudSyncBinding: cloudSyncBinding
                 )
-                
-                if enableCloudSync {
-                    HStack {
-                        Text("iCloud 状态")
-                        Spacer()
-                        Text(cloudKitManager.iCloudStatus)
-                            .foregroundStyle(.secondary)
-                    }
-                    
+            } else {
+                Section {
                     SettingToggleRow(
-                        title: "同步全局设置",
-                        subtitle: "同步代理切换、排序、测速等全局设置",
-                        isOn: Binding(
-                            get: { cloudKitManager.syncGlobalSettings },
-                            set: { cloudKitManager.setSyncOption(globalSettings: $0) }
-                        )
+                        title: "启用 iCloud 同步",
+                        subtitle: "同步服务器配置、全局设置和外观设置到 iCloud",
+                        isOn: cloudSyncBinding
                     )
-                    
-                    SettingToggleRow(
-                        title: "同步控制器列表",
-                        subtitle: "同步所有控制器配置信息",
-                        isOn: Binding(
-                            get: { cloudKitManager.syncServers },
-                            set: { cloudKitManager.setSyncOption(servers: $0) }
-                        )
-                    )
-                    
-                    SettingToggleRow(
-                        title: "同步外观设置",
-                        subtitle: "同步主题、卡片样式等外观设置",
-                        isOn: Binding(
-                            get: { cloudKitManager.syncAppearance },
-                            set: { cloudKitManager.setSyncOption(appearance: $0) }
-                        )
-                    )
-                    
-                    Button {
-                        Task {
-                            do {
-                                try await cloudKitManager.syncToCloud()
-                            } catch {
-                                syncErrorMessage = error.localizedDescription
-                                showSyncErrorAlert = true
-                            }
-                        }
-                    } label: {
-                        HStack {
-                            Label("立即同步到 iCloud", systemImage: "arrow.clockwise.icloud")
-                            Spacer()
-                            if cloudKitManager.isUploadingSyncing {
-                                ProgressView()
-                            }
-                        }
-                    }
-                    .disabled(cloudKitManager.isUploadingSyncing || cloudKitManager.isDownloadingSyncing || cloudKitManager.iCloudStatus != "可用")
-                    
-                    Button {
-                        Task {
-                            do {
-                                try await cloudKitManager.syncFromCloud()
-                            } catch {
-                                syncErrorMessage = error.localizedDescription
-                                showSyncErrorAlert = true
-                            }
-                        }
-                    } label: {
-                        HStack {
-                            Label("从 iCloud 恢复", systemImage: "icloud.and.arrow.down")
-                            Spacer()
-                            if cloudKitManager.isDownloadingSyncing {
-                                ProgressView()
-                            }
-                        }
-                    }
-                    .disabled(cloudKitManager.isUploadingSyncing || cloudKitManager.isDownloadingSyncing || cloudKitManager.iCloudStatus != "可用")
-                }
-            } header: {
-                SectionHeader(title: "iCloud 同步", systemImage: "icloud")
-            } footer: {
-                if enableCloudSync {
-                    Text("上次同步时间：\(cloudKitManager.lastSyncTime?.formatted() ?? "从未同步")")
+                } header: {
+                    SectionHeader(title: "iCloud 同步", systemImage: "icloud")
                 }
             }
             
@@ -362,11 +309,6 @@ struct GlobalSettingsView: View {
         } message: {
             Text("确定要清除所有已缓存的图标吗？")
         }
-        .alert("同步错误", isPresented: $showSyncErrorAlert) {
-            Button("确定", role: .cancel) { }
-        } message: {
-            Text(syncErrorMessage)
-        }
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("SettingsUpdated"))) { _ in
             // 强制视图刷新
             withAnimation {
@@ -374,11 +316,144 @@ struct GlobalSettingsView: View {
                 impact.impactOccurred()
             }
         }
+        .task {
+            // 防呆：若此前已开启过同步但当前环境不支持 iCloud，自动重置开关，
+            // 避免重新进入页面时再次触发 CloudKit 崩溃
+            if enableCloudSync {
+                if !(await CloudKitManager.shared.isICloudAvailable()) {
+                    enableCloudSync = false
+                }
+            }
+            guard enableCloudSync else { return }
+            if cloudKitManager == nil {
+                cloudKitManager = CloudKitManager.shared
+            }
+            await cloudKitManager?.checkICloudStatus()
+        }
+        .onChange(of: enableCloudSync) { newValue in
+            guard newValue else { return }
+            if cloudKitManager == nil {
+                cloudKitManager = CloudKitManager.shared
+            }
+            Task {
+                await cloudKitManager?.checkICloudStatus()
+            }
+        }
+        .alert("无法开启 iCloud 同步", isPresented: $showCloudSyncUnavailableAlert) {
+            Button("知道了", role: .cancel) { }
+        } message: {
+            Text("当前设备环境不支持 iCloud（缺少 iCloud 权限，常见于 LiveContainer 或侧载环境）。该功能仅在 App Store 正常安装并登录 iCloud 后可用。")
+        }
     }
 }
 
 #Preview {
     NavigationStack {
         GlobalSettingsView()
+    }
+}
+
+// MARK: - iCloud 同步子视图
+// 使用 @ObservedObject 观察 CloudKitManager 的发布属性，仅在用户开启同步时创建。
+// 整个 Section（含开关、状态、按钮和页脚）都由本视图渲染，页脚通过 @ObservedObject
+// 实时响应 syncToCloud/syncFromCloud 后的 lastSyncTime 更新，避免显示陈旧值
+private struct ICloudSyncSection: View {
+    @ObservedObject var cloudKitManager: CloudKitManager
+    let cloudSyncBinding: Binding<Bool>
+    @State private var showSyncErrorAlert = false
+    @State private var syncErrorMessage = ""
+    
+    var body: some View {
+        Section {
+            SettingToggleRow(
+                title: "启用 iCloud 同步",
+                subtitle: "同步服务器配置、全局设置和外观设置到 iCloud",
+                isOn: cloudSyncBinding
+            )
+            
+            HStack {
+                Text("iCloud 状态")
+                Spacer()
+                Text(cloudKitManager.iCloudStatus)
+                    .foregroundStyle(.secondary)
+            }
+            
+            SettingToggleRow(
+                title: "同步全局设置",
+                subtitle: "同步代理切换、排序、测速等全局设置",
+                isOn: Binding(
+                    get: { cloudKitManager.syncGlobalSettings },
+                    set: { cloudKitManager.setSyncOption(globalSettings: $0) }
+                )
+            )
+            
+            SettingToggleRow(
+                title: "同步控制器列表",
+                subtitle: "同步所有控制器配置信息",
+                isOn: Binding(
+                    get: { cloudKitManager.syncServers },
+                    set: { cloudKitManager.setSyncOption(servers: $0) }
+                )
+            )
+            
+            SettingToggleRow(
+                title: "同步外观设置",
+                subtitle: "同步主题、卡片样式等外观设置",
+                isOn: Binding(
+                    get: { cloudKitManager.syncAppearance },
+                    set: { cloudKitManager.setSyncOption(appearance: $0) }
+                )
+            )
+            
+            Button {
+                Task {
+                    do {
+                        try await cloudKitManager.syncToCloud()
+                    } catch {
+                        syncErrorMessage = error.localizedDescription
+                        showSyncErrorAlert = true
+                    }
+                }
+            } label: {
+                HStack {
+                    Label("立即同步到 iCloud", systemImage: "arrow.clockwise.icloud")
+                    Spacer()
+                    if cloudKitManager.isUploadingSyncing {
+                        ProgressView()
+                    }
+                }
+            }
+            .disabled(cloudKitManager.isUploadingSyncing || cloudKitManager.isDownloadingSyncing || cloudKitManager.iCloudStatus != "可用")
+            
+            Button {
+                Task {
+                    do {
+                        try await cloudKitManager.syncFromCloud()
+                    } catch {
+                        syncErrorMessage = error.localizedDescription
+                        showSyncErrorAlert = true
+                    }
+                }
+            } label: {
+                HStack {
+                    Label("从 iCloud 恢复", systemImage: "icloud.and.arrow.down")
+                    Spacer()
+                    if cloudKitManager.isDownloadingSyncing {
+                        ProgressView()
+                    }
+                }
+            }
+            .disabled(cloudKitManager.isUploadingSyncing || cloudKitManager.isDownloadingSyncing || cloudKitManager.iCloudStatus != "可用")
+        } header: {
+            SectionHeader(title: "iCloud 同步", systemImage: "icloud")
+        } footer: {
+            // 页脚随 @ObservedObject 的 lastSyncTime 变化实时刷新
+            Text("上次同步时间：\(cloudKitManager.lastSyncTime?.formatted() ?? "从未同步")")
+        }
+        .alert("同步错误", isPresented: $showSyncErrorAlert) {
+            Button("确定", role: .cancel) { }
+        } message: {
+            Text(syncErrorMessage)
+        }
     }
 } 

--- a/Clash Dash/Views/Settings/GlobalSettingsView.swift
+++ b/Clash Dash/Views/Settings/GlobalSettingsView.swift
@@ -114,25 +114,59 @@ struct GlobalSettingsView: View {
     @State private var showClearCacheAlert = false
     @State private var cloudKitManager: CloudKitManager?
     @State private var showCloudSyncUnavailableAlert = false
+    // 异步探测期间的开关缓冲 + 取消令牌（单调递增）。
+    // 布尔令牌存在 ABA 问题（ON→OFF→ON 快速连点时旧 Task 会误判通过），
+    // 改用单调递增 token：每次开启分配新 token，Task 恢复后校验 token 是否仍为自己持有。
+    // 探测本身由 .task(id: cloudSyncPendingToken) 结构化并发驱动，
+    // 视图消失时 SwiftUI 自动取消 in-flight 探测，避免向脱离层级的 @State 写入
+    @State private var isCloudSyncPending = false
+    @State private var cloudSyncPendingToken = 0
     
-    /// 防呆：环境不支持 iCloud 时阻止开启同步，并提示用户
+    /// 防呆：环境不支持 iCloud 时阻止开启同步，并提示用户。
+    /// 侧载环境快路径为同步判断（纯路径检查，不触碰 CloudKit API）；
+    /// 其余环境通过 checkICloudStatus 单次探测 accountStatus 确认可用后才真正开启。
+    /// 探测期间用 isCloudSyncPending 缓冲开关状态（Toggle 立即置 ON），
+    /// 探测失败时回弹到 OFF 并弹窗，避免用户感知到异步等待的闪烁
     private var cloudSyncBinding: Binding<Bool> {
         Binding(
-            get: { enableCloudSync },
+            get: { enableCloudSync || isCloudSyncPending },
             set: { newValue in
                 guard newValue else {
                     enableCloudSync = false
+                    isCloudSyncPending = false
+                    cloudSyncPendingToken += 1  // 使所有 in-flight 探测失效
                     return
                 }
-                Task {
-                    if await CloudKitManager.shared.isICloudAvailable() {
-                        enableCloudSync = true
-                    } else {
-                        showCloudSyncUnavailableAlert = true
-                    }
+                // 侧载环境（如 LiveContainer）同步拦截，立即弹窗提示
+                if CloudKitManager.shared.isSideLoadedEnvironment {
+                    showCloudSyncUnavailableAlert = true
+                    return
                 }
+                // 乐观更新：Toggle 立即置 ON；token 自增触发 .task(id:) 重新探测
+                isCloudSyncPending = true
+                cloudSyncPendingToken += 1
             }
         )
+    }
+    
+    /// 探测任务：由 cloudSyncPendingToken 驱动，token 变化时重新执行；
+    /// 视图消失时 SwiftUI 自动取消，配合守卫链（取消检查 + token 匹配）保证写回安全
+    private func runCloudSyncProbe() async {
+        // OFF 时 token 也会自增触发本任务，直接返回
+        guard isCloudSyncPending else { return }
+        let myToken = cloudSyncPendingToken
+        await CloudKitManager.shared.checkICloudStatus()
+        // 守卫 1：视图已消失 / 任务被取消，放弃写回
+        guard !Task.isCancelled else { return }
+        // 守卫 2：探测期间 token 已变化（OFF 或再次 ON），本次结果作废（防 ABA）
+        guard cloudSyncPendingToken == myToken else { return }
+        let available = CloudKitManager.shared.iCloudStatus == "可用"
+        isCloudSyncPending = false
+        if available {
+            enableCloudSync = true
+        } else {
+            showCloudSyncUnavailableAlert = true
+        }
     }
     
     var body: some View {
@@ -318,26 +352,31 @@ struct GlobalSettingsView: View {
         }
         .task {
             // 防呆：若此前已开启过同步但当前环境不支持 iCloud，自动重置开关，
-            // 避免重新进入页面时再次触发 CloudKit 崩溃
-            if enableCloudSync {
-                if !(await CloudKitManager.shared.isICloudAvailable()) {
-                    enableCloudSync = false
-                }
-            }
+            // 避免重新进入页面时再次触发 CloudKit 崩溃（checkICloudStatus 内部有侧载快路径拦截）
             guard enableCloudSync else { return }
             if cloudKitManager == nil {
                 cloudKitManager = CloudKitManager.shared
             }
             await cloudKitManager?.checkICloudStatus()
+            if cloudKitManager?.iCloudStatus != "可用" {
+                enableCloudSync = false
+            }
         }
         .onChange(of: enableCloudSync) { newValue in
-            guard newValue else { return }
-            if cloudKitManager == nil {
-                cloudKitManager = CloudKitManager.shared
+            if newValue {
+                // 开启同步：cloudSyncBinding 已探测过 iCloud 状态，这里只需确保 manager 存在
+                if cloudKitManager == nil {
+                    cloudKitManager = CloudKitManager.shared
+                }
+            } else {
+                // 关闭同步：释放对 CloudKitManager 的持有，避免常驻单例引用
+                cloudKitManager = nil
             }
-            Task {
-                await cloudKitManager?.checkICloudStatus()
-            }
+        }
+        // 探测任务绑定视图生命周期：token 变化时重新探测，视图消失时自动取消，
+        // 避免 in-flight 探测在导航离开后向脱离层级的 @State 写入
+        .task(id: cloudSyncPendingToken) {
+            await runCloudSyncProbe()
         }
         .alert("无法开启 iCloud 同步", isPresented: $showCloudSyncUnavailableAlert) {
             Button("知道了", role: .cancel) { }

--- a/Shared/SharedModels.swift
+++ b/Shared/SharedModels.swift
@@ -1,4 +1,7 @@
 import Foundation
+import OSLog
+
+private let sharedDataLogger = Logger(subsystem: "com.mou.ClashDash", category: "SharedDataManager")
 
 // MARK: - 共享的数据管理器
 public class SharedDataManager {
@@ -17,10 +20,14 @@ public class SharedDataManager {
     }
     
     private init() {
-        guard let userDefaults = UserDefaults(suiteName: appGroupId) else {
-            fatalError("无法访问 App Group")
+        if let suiteDefaults = UserDefaults(suiteName: appGroupId) {
+            userDefaults = suiteDefaults
+        } else {
+            // App Group 容器不可用（如 LiveContainer 或未配置 App Group 权限时），
+            // 降级为标准 UserDefaults，避免 fatalError 崩溃，同时输出警告日志便于排查
+            sharedDataLogger.warning("App Group「\(self.appGroupId, privacy: .public)」不可用，已降级使用 UserDefaults.standard（常见于 LiveContainer 或未配置 App Group 权限的环境）")
+            userDefaults = UserDefaults.standard
         }
-        self.userDefaults = userDefaults
     }
     
     public func saveClashStatus(


### PR DESCRIPTION
目前 IPA 在 LiveContainer 下侧载打开之后直接闪退，抓日志定位到是 CloudKit 相关依赖加载导致的问题，原因似乎是自签环境下无法调用 iCloud 相关服务，所以本 PR 的改动思路是:

1. 提前检测 iCloud 是否可用，并按需进行相关服务加载，自测使用没有问题。
2. 开启开关时，再次检测检测 iCloud 是否可用，不可用继续弹窗拦截；

我自己本地已经用 GLM 5.2 测了几轮（见 https://github.com/bgzo/Clash-Dash/pull/1 ,https://github.com/bgzo/Clash-Dash/pull/2)

## 改造后截图

<img width="603" height="1311" alt="IMG_9039" src="https://github.com/user-attachments/assets/030136f4-26ab-468e-a308-0e14fbf17d7a" />

## 相关 ISSUE 

- #33 

## 延伸问题1：GitHub Action 打包问题

我在 Fork 仓库里面用了下 GA 的打包功能，遇到了内部编译问题：

```bash
2026-08-16T03:51:21.2363740Z } // end sil function '$s10Clash_Dash15ServerViewModelC10urlSession_10didReceive17completionHandlerySo12NSURLSessionC_So28NSURLAuthenticationChallengeCySo0l4AuthN11DispositionV_So15NSURLCredentialCSgtctF'
2026-08-16T03:51:21.2364510Z 
2026-08-16T03:51:21.2364620Z Invalid SIL provided to OSSACompleteLifetime?! }}
2026-08-16T03:51:21.2365540Z Something that ran before OSSACompleteLifetime (the current pass, an earlier pass, SILGen) has introduced a leak of this value.
2026-08-16T03:51:21.2366730Z Please rerun the crashing swift-frontend command with the following flags added and file a bug with the output:
2026-08-16T03:51:21.2368450Z -sil-ownership-verify-all -Xllvm '-sil-print-function=$s10Clash_Dash15ServerViewModelC10urlSession_10didReceive17completionHandlerySo12NSURLSessionC_So28NSURLAuthenticationChallengeCySo0l4AuthN11DispositionV_So15NSURLCredentialCSgtctF' -Xllvm -sil-print-types -Xllvm -sil-print-module-on-error
2026-08-16T03:51:21.2370050Z Use the -disable-sil-ownership-verifier frontend flag to disable this check.
2026-08-16T03:51:21.2371020Z Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
2026-08-16T03:51:21.2372660Z Stack dump:
#....
2026-08-16T03:51:21.2562230Z 1.	Apple Swift version 6.3.3 (swiftlang-6.3.3.1.3 clang-2100.1.1.101)
2026-08-16T03:51:21.2562630Z 2.	Compiling with effective version 5.10
2026-08-16T03:51:21.2564590Z 3.	While evaluating request ExecuteSILPipelineRequest(Run pipelines { PrepareOptimizationPasses, EarlyModulePasses, HighLevel,Function+EarlyLoopOpt, HighLevel,Module+StackPromote, MidLevel,Function, ClosureSpecialize, LowLevel,Function, LateLoopOpt, SIL Debug Info Generator } on SIL for Clash_Dash)
2026-08-16T03:51:21.2566890Z 4.	While running pass #52104 SILFunctionTransform "CopyPropagation" on SILFunction "@$s10Clash_Dash15ServerViewModelC10urlSession_10didReceive17completionHandlerySo12NSURLSessionC_So28NSURLAuthenticationChallengeCySo0l4AuthN11DispositionV_So15NSURLCredentialCSgtctF".
2026-08-16T03:51:21.2568170Z  for 'urlSession(_:didReceive:completionHandler:)' (at /Users/runner/work/Clash-Dash/Clash-Dash/Clash Dash/ViewModels/ServerViewModel.swift:294:17)
2026-08-16T03:51:21.2569010Z Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):

# via: https://productionresultssa8.blob.core.windows.net/actions-results/5d16107d-39c4-4101-882d-1424d2c3f124/workflow-job-run-c93ae5cf-e400-5704-b2b6-186444a844b1/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-08-19T11%3A24%3A35Z&sig=jem12mZqvEq75h%2BAr1f0IrBeClXdgxp%2FoONsB%2FjBMXI%3D&ske=2026-08-19T14%3A45%3A25Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-08-19T10%3A45%3A25Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-08-19T11%3A14%3A30Z&sv=2025-11-05
```

定位到是 https://github.com/bgzo/Clash-Dash/commit/307dca1198f21a83ce2764169622bcc0f717970e 这里并发的写法会导致 GA 编译错误（资源耗尽 OOM？），最终导致失败，自测改变写法后，可以顺利编译通过，https://github.com/bgzo/Clash-Dash/releases 不过这个不在本次 PR 范围内，需要的话，我之后提上来。

## 延伸问题2: 代码问题

提出来解决方案是一回事，能不能合并是另是一回事，因为我猜代码其实不是最新的，因为我发现这里编译出来的，和最新的 Neko Dash 有一些地方不太一样，代码可能合并有困难？

另外吐槽一下 Neko Dash 的定期检测，感觉是一个月吧，我付费在国区，日常使用在外区，着急用的时候突然卡住，得去设置切商店，还挺尴尬的。（我之前买过 Clash Dash，后来也顺利迁移到了 Neko Dash）

## 附：系统分析日志

```
-------------------------------------
Translated Report (Full Report Below)
-------------------------------------
Process:             LiveContainer [6201]
Path:                /private/var/containers/Bundle/Application/4B4F562A-BAE8-429F-87AC-D3003E51C6EA/App.app/LiveContainer
Identifier:          com.kdt.livecontainer.F9T35HM6GL
Version:             3.7.2 (3.7.2)
Code Type:           ARM-64 (Native)
Role:                Foreground
Parent Process:      launchd [1]
Coalition:           com.kdt.livecontainer.F9T35HM6GL [2082]
User ID:             501

Date/Time:           2026-08-17 08:05:43.5600 +0800
Launch Time:         2026-08-17 08:05:43.3334 +0800
Hardware Model:      iPad16,1
OS Version:          iPhone OS 26.6 (23G71)
Release Type:        User

Crash Reporter Key:  bfa7e0cccc048b96a930b57d08f075cbf709b34e
Incident Identifier: 457727A8-7AF8-4456-BC28-5AF160E7D6CA

Time Awake Since Boot: 150000 seconds

Triggered by Thread: 0, Dispatch Queue: com.apple.main-thread

Exception Type:    EXC_BREAKPOINT (SIGTRAP)
Exception Codes:   0x0000000000000001, 0x00000001984994c0

Termination Reason:  Namespace SIGNAL, Code 5, Trace/BPT trap: 5
Terminating Process: exc handler [6201]


Thread 0 name:   Dispatch queue: com.apple.main-thread
Thread 0 Crashed:
0   CloudKit                      	       0x1984994c0 0x19848e000 + 46272
1   CloudKit                      	       0x198498aa8 0x19848e000 + 43688
2   CloudKit                      	       0x19849f548 0x19848e000 + 70984
3   CloudKit                      	       0x19849f4d8 0x19848e000 + 70872
4   libdispatch.dylib             	       0x1cda0b1e4 _dispatch_client_callout + 16
5   libdispatch.dylib             	       0x1cd9f45b0 _dispatch_once_callout + 32
6   CloudKit                      	       0x19849f4b4 0x19848e000 + 70836
7   Clash Dash                    	       0x10d12a034 0x10d0bc000 + 450612
8   Clash Dash                    	       0x10d129cb8 0x10d0bc000 + 449720
9   libdispatch.dylib             	       0x1cda0b1e4 _dispatch_client_callout + 16
10  libdispatch.dylib             	       0x1cd9f45b0 _dispatch_once_callout + 32
11  Clash Dash                    	       0x10d4c0a04 0x10d0bc000 + 4213252
12  SwiftUICore                   	       0x19d2f20f0 StateObject.Box.update(property:phase:) + 468
13  SwiftUICore                   	       0x19d23cef4 static BoxVTable.update(elt:property:phase:) + 384
14  SwiftUICore                   	       0x19d23d1c4 _DynamicPropertyBuffer.update(container:phase:) + 144
15  SwiftUICore                   	       0x19d23cd20 closure #1 in closure #1 in DynamicBody.updateValue() + 304
16  SwiftUICore                   	       0x19d23cd6c partial apply for closure #1 in closure #1 in DynamicBody.updateValue() + 32
17  SwiftUICore                   	       0x19d224730 withUnsafeMutablePointer<A, B, C>(to:_:) + 160
18  SwiftUICore                   	       0x19d23c810 closure #1 in DynamicBody.updateValue() + 476
19  SwiftUICore                   	       0x19d23c224 DynamicBody.updateValue() + 1220
20  SwiftUICore                   	       0x19d717fd0 partial apply for implicit closure #1 in closure #1 in closure #1 in Attribute.init<A>(_:) + 32
21  AttributeGraph                	       0x1c66d0914 AG::Graph::UpdateStack::update() + 496
-------- RECURSION LEVEL 22
22  AttributeGraph                	       0x1c66d052c AG::Graph::update_attribute(AG::data::ptr<AG::Node>, unsigned int) + 352
23  AttributeGraph                	       0x1c66cfe68 AG::Graph::input_value_ref_slow(AG::data::ptr<AG::Node>, AG::AttributeID, unsigned int, unsigned int, AGSwiftMetadata const*, unsigned char&, long) + 680
24  AttributeGraph                	       0x1c66ca2a8 AGGraphGetValue + 232
25  SwiftUICore                   	       0x19d23b0a8 StaticBody.container.getter + 84
26  SwiftUICore                   	       0x19d23afb0 closure #1 in StaticBody.updateValue() + 436
27  SwiftUICore                   	       0x19d23a774 StaticBody.updateValue() + 836
28  SwiftUICore                   	       0x19d717fd0 partial apply for implicit closure #1 in closure #1 in closure #1 in Attribute.init<A>(_:) + 32
29  AttributeGraph                	       0x1c66d0914 AG::Graph::UpdateStack::update() + 496
-------- RECURSION LEVEL 21
30  AttributeGraph                	       0x1c66d052c AG::Graph::update_attribute(AG::data::ptr<AG::Node>, unsigned int) + 352
31  AttributeGraph                	       0x1c66cfe68 AG::Graph::input_value_ref_slow(AG::data::ptr<AG::Node>, AG::AttributeID, unsigned int, unsigned int, AGSwiftMetadata const*, unsigned char&, long) + 680
32  AttributeGraph                	       0x1c66ca2a8 AGGraphGetValue + 232
33  SwiftUI                       	       0x19c174994 MakeBody.value.getter + 156
34  SwiftUICore                   	       0x19d9b70ac implicit closure #1 in closure #1 in closure #1 in Attribute.init<A>(_:) + 324
35  AttributeGraph                	       0x1c66d0914 AG::Graph::UpdateStack::update() + 496
-------- RECURSION LEVEL 20
--------
-------- ELIDED 16 LEVELS OF RECURSION THROUGH 0x1c66d0914 AG::Graph::UpdateStack::update() + 496
--------
134 AttributeGraph                	       0x1c66d052c AG::Graph::update_attribute(AG::data::ptr<AG::Node>, unsigned int) + 352
135 AttributeGraph                	       0x1c66cfe68 AG::Graph::input_value_ref_slow(AG::data::ptr<AG::Node>, AG::AttributeID, unsigned int, unsigned int, AGSwiftMetadata const*, unsigned char&, long) + 680
136 AttributeGraph                	       0x1c66d112c AGGraphGetInputValue + 252
137 SwiftUICore                   	       0x19d28b3f8 StackLayout.makeChildren() + 972
138 SwiftUICore                   	       0x19d29f5e8 specialized HVStack.updateCache(_:subviews:) + 256
139 SwiftUICore                   	       0x19d29f4a4 specialized ViewLayoutEngine.update(layout:context:children:) + 576
140 SwiftUICore                   	       0x19d29f250 partial apply for specialized closure #1 in Layout.updateLayoutComputer<A>(rule:layoutContext:children:) + 56
141 SwiftUICore                   	       0x19d29f188 <deduplicated_symbol> + 28
142 SwiftUICore                   	       0x19d29f160 <deduplicated_symbol> + 28
143 SwiftUICore                   	       0x19d29f134 partial apply for closure #1 in LayoutEngineBox.mutateEngine<A, B>(as:do:) + 32
144 SwiftUICore                   	       0x19d224730 withUnsafeMutablePointer<A, B, C>(to:_:) + 160
145 SwiftUICore                   	       0x19d29f0b0 LayoutEngineBox.mutateEngine<A, B>(as:do:) + 208
146 SwiftUICore                   	       0x19dbdb7fc <deduplicated_symbol> + 400
147 SwiftUICore                   	       0x19d27a410 specialized StatefulRule<>.updateLayoutComputer<A>(layout:environment:attributes:) + 244
148 SwiftUICore                   	       0x19d27a2e4 specialized DynamicLayoutComputer.updateValue() + 288
149 SwiftUICore                   	       0x19dbf8c54 specialized implicit closure #1 in closure #1 in closure #1 in Attribute.init<A>(_:) + 96
150 AttributeGraph                	       0x1c66d0914 AG::Graph::UpdateStack::update() + 496
-------- RECURSION LEVEL 3
151 AttributeGraph                	       0x1c66d052c AG::Graph::update_attribute(AG::data::ptr<AG::Node>, unsigned int) + 352
152 AttributeGraph                	       0x1c66cfe68 AG::Graph::input_value_ref_slow(AG::data::ptr<AG::Node>, AG::AttributeID, unsigned int, unsigned int, AGSwiftMetadata const*, unsigned char&, long) + 680
153 AttributeGraph                	       0x1c66ca2a8 AGGraphGetValue + 232
154 SwiftUICore                   	       0x19d2a04e0 DynamicLayoutViewChildGeometry.updateValue() + 260
155 SwiftUICore                   	       0x19dbf7c68 specialized implicit closure #1 in closure #1 in closure #1 in Attribute.init<A>(_:) + 24
156 AttributeGraph                	       0x1c66d0914 AG::Graph::UpdateStack::update() + 496
-------- RECURSION LEVEL 2
157 AttributeGraph                	       0x1c66d052c AG::Graph::update_attribute(AG::data::ptr<AG::Node>, unsigned int) + 352
158 AttributeGraph                	       0x1c66cfe68 AG::Graph::input_value_ref_slow(AG::data::ptr<AG::Node>, AG::AttributeID, unsigned int, unsigned int, AGSwiftMetadata const*, unsigned char&, long) + 680
159 AttributeGraph                	       0x1c66ca2a8 AGGraphGetValue + 232
160 SwiftUICore                   	       0x19d291754 AnimatableFrameAttribute.updateValue() + 68
161 SwiftUICore                   	       0x19dbf5edc specialized implicit closure #1 in closure #1 in closure #1 in Attribute.init<A>(_:) + 24
162 AttributeGraph                	       0x1c66d0914 AG::Graph::UpdateStack::update() + 496
-------- RECURSION LEVEL 1
163 AttributeGraph                	       0x1c66d274c AG::Subgraph::update(unsigned int) + 972
164 SwiftUICore                   	       0x19d29d040 specialized GraphHost.runTransaction(_:do:id:) + 368
165 SwiftUICore                   	       0x19d23579c GraphHost.flushTransactions() + 180
166 SwiftUICore                   	       0x19d234bd8 closure #1 in ViewGraphRootValueUpdater.render(interval:updateDisplayList:targetTimestamp:) + 880
167 SwiftUICore                   	       0x19d234818 ViewGraphRootValueUpdater.render(interval:updateDisplayList:targetTimestamp:) + 584
168 UIKitCore                     	       0x198cd6d04 0x198af4000 + 1977604
169 SwiftUI                       	       0x19bf5dbbc _UIHostingView.layoutSubviews() + 116
170 SwiftUI                       	       0x19bf5db24 @objc _UIHostingView.layoutSubviews() + 36
171 UIKitCore                     	       0x198b3c1a0 0x198af4000 + 295328
172 UIKitCore                     	       0x198b3caec 0x198af4000 + 297708
173 UIKitCore                     	       0x198b3b0a0 -[UIView(CALayerDelegate) layoutSublayersOfLayer:] + 2684
174 QuartzCore                    	       0x193b5c8a4 CA::Layer::perform_update_(CA::Layer*, CALayer*, unsigned int, CA::LayerUpdateReason, CA::Transaction*) + 460
175 QuartzCore                    	       0x193b5c3f4 CA::Layer::update_if_needed_(CA::Transaction*, CA::LayerUpdateReason) + 664
176 QuartzCore                    	       0x19394e800 CA::Layer::layout_and_display_if_needed(CA::Transaction*) + 180
177 QuartzCore                    	       0x19390d198 CA::Context::commit_transaction(CA::Transaction*, double, double*) + 560
178 QuartzCore                    	       0x193939520 CA::Transaction::commit() + 620
179 UIKitCore                     	       0x198d3a4fc __34-[UIApplication _firstCommitBlock]_block_invoke_2 + 36
180 CoreFoundation                	       0x192ee0acc __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 28
181 CoreFoundation                	       0x192ee0798 __CFRunLoopDoBlocks + 396
182 CoreFoundation                	       0x192ee21bc __CFRunLoopRun + 848
183 CoreFoundation                	       0x192ee154c _CFRunLoopRunSpecificWithOptions + 532
184 GraphicsServices              	       0x238aa5498 GSEventRunModal + 120
185 UIKitCore                     	       0x198c15670 -[UIApplication _run] + 796
186 UIKitCore                     	       0x198b80158 UIApplicationMain + 332
187 SwiftUI                       	       0x19bf6f570 closure #1 in KitRendererCommon(_:) + 168
188 SwiftUI                       	       0x19bf6c0f4 runApp<A>(_:) + 112
189 SwiftUI                       	       0x19bf6bc48 static App.main() + 172
190 Clash Dash                    	       0x10d52f208 0x10d0bc000 + 4665864
191 LiveContainerShared           	       0x104f86050 LiveContainerMain + 8420
192 dyld                          	       0x18faedc1c start + 6928

Thread 1:

Thread 2:

Thread 3:

Thread 4:

Thread 5:

Thread 6 name:  com.apple.uikit.eventfetch-thread
Thread 6:
0   libsystem_kernel.dylib        	       0x242358cd4 mach_msg2_trap + 8
1   libsystem_kernel.dylib        	       0x24235c30c mach_msg2_internal + 76
2   libsystem_kernel.dylib        	       0x24235c22c mach_msg_overwrite + 424
3   libsystem_kernel.dylib        	       0x24235c078 mach_msg + 24
4   CoreFoundation                	       0x192f18344 __CFRunLoopServiceMachPort + 160
5   CoreFoundation                	       0x192ee2310 __CFRunLoopRun + 1188
6   CoreFoundation                	       0x192ee154c _CFRunLoopRunSpecificWithOptions + 532
7   Foundation                    	       0x19014ecf0 -[NSRunLoop(NSRunLoop) runMode:beforeDate:] + 212
8   Foundation                    	       0x19014ebd8 -[NSRunLoop(NSRunLoop) runUntilDate:] + 64
9   UIKitCore                     	       0x198bdaeac -[UIEventFetcher threadMain] + 420
10  Foundation                    	       0x1901d2904 __NSThread__start__ + 732
11  libsystem_pthread.dylib       	       0x1f27c2438 _pthread_start + 136
12  libsystem_pthread.dylib       	       0x1f27be8cc thread_start + 8

Thread 7:

Thread 8:

Thread 9:


Thread 0 crashed with ARM Thread State (64-bit):
    x0: 0x000000010d8fa311   x1: 0x0000000000000000   x2: 0x0000000000000001   x3: 0x0000000000000000
    x4: 0x000000010db901c0   x5: 0x000000000000000f   x6: 0xffffffffbfc007ff   x7: 0xfffff0003ffff800
    x8: 0x00000001f99e4000   x9: 0x69d2ab8b214e00f4  x10: 0x0000000000000005  x11: 0x000000000000003f
   x12: 0x000000000023b623  x13: 0x300000010dbf4080  x14: 0x01000001fc5cb461  x15: 0x00000001fc5cb460
   x16: 0x000000019ea40d24  x17: 0x0000000192ed5218  x18: 0x0000000000000000  x19: 0x00000001feaebd20
   x20: 0x00000001feb04080  x21: 0x000000010a245300  x22: 0x000000010dac53e0  x23: 0x000000010dacad00
   x24: 0x00000001feb04060  x25: 0x0000000000000000  x26: 0x0000000000000000  x27: 0x000000016aede360
   x28: 0x000000016aede370   fp: 0x000000016aede290   lr: 0x00000001984994c0
    sp: 0x000000016aede0f0   pc: 0x00000001984994c0 cpsr: 0x60001000
   far: 0x0000000000000000  esr: 0xf2000001 (Breakpoint) brk 1

Binary Images:
       0x104f14000 -        0x104f1bfff LiveContainer arm64  <e01d22cc3aa2357f81cd3791065727e5> /private/var/containers/Bundle/Application/4B4F562A-BAE8-429F-87AC-D3003E51C6EA/App.app/LiveContainer
       0x104f78000 -        0x104f8ffff LiveContainerShared arm64  <2cd08a76a0f738678dbf587909d198dc> /private/var/containers/Bundle/Application/4B4F562A-BAE8-429F-87AC-D3003E51C6EA/App.app/Frameworks/LiveContainerShared.framework/LiveContainerShared
       0x10d0bc000 -        0x10d6d3fff Clash Dash arm64  <6ef609c6cdc333ad9e0435d36e1d881c> /private/var/mobile/Containers/Data/Application/C214B7D5-33C6-4554-9005-63CD567C1107/Documents/Applications/ym.si.clashdash.app/Clash Dash
       0x105010000 -        0x10501ffff Shared arm64  <c228b054a31737eca439afd31496967e> /private/var/mobile/Containers/Data/Application/C214B7D5-33C6-4554-9005-63CD567C1107/Documents/Applications/ym.si.clashdash.app/Frameworks/Shared.framework/Shared
       0x105038000 -        0x105047fff TweakLoader.dylib arm64  <243f2cf387ce37eca98d4e94fcd46601> /private/var/containers/Bundle/Application/4B4F562A-BAE8-429F-87AC-D3003E51C6EA/App.app/Frameworks/TweakLoader.dylib
       0x10515c000 -        0x105167fff libobjc-trampolines.dylib arm64e  <6893bf2adb4b33d9875deea7cb8f8060> /private/preboot/Cryptexes/OS/usr/lib/libobjc-trampolines.dylib
       0x19848e000 -        0x19889643f CloudKit arm64e  <8bb783dfe71b3961bfc0e9808d1326a1> /System/Library/Frameworks/CloudKit.framework/CloudKit
       0x1cd9f0000 -        0x1cda365ff libdispatch.dylib arm64e  <955b1789d5423497b46dbd6be85f91a2> /usr/lib/system/libdispatch.dylib
       0x19d218000 -        0x19e1147bf SwiftUICore arm64e  <e47d2d7d0a0a3bfdab6a3e86a7cd0b23> /System/Library/Frameworks/SwiftUICore.framework/SwiftUICore
       0x1c66c4000 -        0x1c670919f AttributeGraph arm64e  <feb8885561103eeb9ad0198805fd4fe8> /System/Library/PrivateFrameworks/AttributeGraph.framework/AttributeGraph
       0x19bf3f000 -        0x19d1ca99f SwiftUI arm64e  <fd601f351f633a018d2c9c3d01a79a24> /System/Library/Frameworks/SwiftUI.framework/SwiftUI
       0x198af4000 -        0x19b03763f UIKitCore arm64e  <26334227f5583da7985d326a0c894dd4> /System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore
       0x19389f000 -        0x193c8febf QuartzCore arm64e  <a30444a606c13996b8390c172e74ed39> /System/Library/Frameworks/QuartzCore.framework/QuartzCore
       0x192eb3000 -        0x19344f9bf CoreFoundation arm64e  <5565cad9494132ac8b107d3233c74151> /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation
       0x238aa4000 -        0x238aac7bf GraphicsServices arm64e  <7915658c77283149a5242164c163f3d2> /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices
       0x18fae9000 -        0x18fb8e47f dyld arm64e  <0ba28ce287183cb3bef46dd44464ebe2> /usr/lib/dyld
               0x0 - 0xffffffffffffffff ??? unknown-arch  <00000000000000000000000000000000> ???
       0x19ea30000 -        0x19eaaf5ff libsystem_c.dylib arm64e  <ca7f1aef8c1f33a2b1cc52d9ab644bea> /usr/lib/system/libsystem_c.dylib
       0x242358000 -        0x242393b1f libsystem_kernel.dylib arm64e  <a11bf43317ab3f0188bc54c467ce6287> /usr/lib/system/libsystem_kernel.dylib
       0x190144000 -        0x190fcdc1f Foundation arm64e  <1689fea517803efe8f31933d4db24ec4> /System/Library/Frameworks/Foundation.framework/Foundation
       0x1f27be000 -        0x1f27ca4ef libsystem_pthread.dylib arm64e  <46b95807f7523dc2a1ba6290e8d7fe38> /usr/lib/system/libsystem_pthread.dylib

VM Region Summary:
ReadOnly portion of Libraries: Total=1.7G resident=0K(0%) swapped_out_or_unallocated=1.7G(100%)
Writable regions: Total=100.8M written=593K(1%) resident=593K(1%) swapped_out=0K(0%) unallocated=100.2M(99%)

                                VIRTUAL   REGION 
REGION TYPE                        SIZE    COUNT (non-coalesced) 
===========                     =======  ======= 
Activity Tracing                   256K        1 
AttributeGraph Data               1024K        1 
ColorSync                           16K        1 
CoreAnimation                       48K        3 
Foundation                          16K        1 
Kernel Alloc Once                   32K        1 
MALLOC                            28.8M       14 
MALLOC guard page                 3904K        4 
Memory Tag 22                     64.0M        1 
STACK GUARD                        160K       10 
Stack                             5904K       10 
VM_ALLOCATE                        144K        1 
__AUTH                            8336K      716 
__AUTH_CONST                     104.7M     1133 
__CTF                               824        1 
__DATA                            44.3M     1078 
__DATA_CONST                      36.1M     1143 
__DATA_DIRTY                      9884K      998 
__FONT_DATA                        2352        1 
__LINKEDIT                       179.8M        7 
__OBJC_RO                         84.8M        1 
__OBJC_RW                         3182K        1 
__TEXT                             1.6G     1158 
__TPRO_CONST                       128K        2 
mapped file                      401.6M       26 
page table in kernel               593K        1 
shared memory                       80K        4 
===========                     =======  ======= 
TOTAL                              2.5G     6318 


-----------
Full Report
-----------

{"app_name":"LiveContainer","timestamp":"2026-08-17 08:05:44.00 +0800","app_version":"3.7.2","slice_uuid":"e01d22cc-3aa2-357f-81cd-3791065727e5","build_version":"3.7.2","platform":2,"bundleID":"com.kdt.livecontainer.F9T35HM6GL","share_with_app_devs":0,"is_first_party":0,"bug_type":"309","os_version":"iPhone OS 26.6 (23G71)","roots_installed":0,"name":"LiveContainer","incident_id":"457727A8-7AF8-4456-BC28-5AF160E7D6CA"}
{
  "uptime" : 150000,
  "procRole" : "Foreground",
  "version" : 2,
  "userID" : 501,
  "deployVersion" : 210,
  "modelCode" : "iPad16,1",
  "coalitionID" : 2082,
  "osVersion" : {
    "isEmbedded" : true,
    "train" : "iPhone OS 26.6",
    "releaseType" : "User",
    "build" : "23G71"
  },
  "captureTime" : "2026-08-17 08:05:43.5600 +0800",
  "codeSigningMonitor" : 2,
  "incident" : "457727A8-7AF8-4456-BC28-5AF160E7D6CA",
  "pid" : 6201,
  "translated" : false,
  "cpuType" : "ARM-64",
  "procLaunch" : "2026-08-17 08:05:43.3334 +0800",
  "procStartAbsTime" : 3728518089963,
  "procExitAbsTime" : 3728523504351,
  "procName" : "LiveContainer",
  "procPath" : "\/private\/var\/containers\/Bundle\/Application\/4B4F562A-BAE8-429F-87AC-D3003E51C6EA\/App.app\/LiveContainer",
  "bundleInfo" : {"CFBundleShortVersionString":"3.7.2","CFBundleVersion":"3.7.2","CFBundleIdentifier":"com.kdt.livecontainer.F9T35HM6GL"},
  "storeInfo" : {"deviceIdentifierForVendor":"B85897A4-D7CD-4F00-A7B2-652ECFE3B375","thirdParty":true},
  "parentProc" : "launchd",
  "parentPid" : 1,
  "coalitionName" : "com.kdt.livecontainer.F9T35HM6GL",
  "crashReporterKey" : "bfa7e0cccc048b96a930b57d08f075cbf709b34e",
  "lowPowerMode" : 1,
  "appleIntelligenceStatus" : {"state":"unavailable","reasons":["regionIneligible"]},
  "developerMode" : 1,
  "bootProgressRegister" : "0x2080000c",
  "wasUnlockedSinceBoot" : 1,
  "isLocked" : 0,
  "codeSigningID" : "com.kdt.livecontainer.F9T35HM6GL",
  "codeSigningTeamID" : "F9T35HM6GL",
  "codeSigningFlags" : 570434309,
  "codeSigningValidationCategory" : 3,
  "codeSigningTrustLevel" : 4,
  "codeSigningAuxiliaryInfo" : 9007199254740992,
  "instructionByteStream" : {"beforePC":"AJVB+fPTAKn4AwD5ojIzsEIALpFd5w+U\/QMdqmf3NJUyaw+U4fQ0lQ==","atPC":"IAAg1PMDAKrowwGRAIEAkdD2NJUIAAAUAQAAFPMDAKoFAAAU8wMAqg=="},
  "bootSessionUUID" : "EDA89D49-CBAC-4F01-8DEC-CD3CDEBF9105",
  "exception" : {"codes":"0x0000000000000001, 0x00000001984994c0","rawCodes":[1,6849926336],"type":"EXC_BREAKPOINT","signal":"SIGTRAP"},
  "termination" : {"flags":0,"code":5,"namespace":"SIGNAL","indicator":"Trace\/BPT trap: 5","byProc":"exc handler","byPid":6201},
  "os_fault" : {"process":"LiveContainer"},
  "faultingThread" : 0,
  "threads" : [{"frames":[{"imageOffset":46272,"imageIndex":6},{"imageOffset":43688,"imageIndex":6},{"imageOffset":70984,"imageIndex":6},{"imageOffset":70872,"imageIndex":6},{"imageOffset":111076,"symbol":"_dispatch_client_callout","symbolLocation":16,"imageIndex":7},{"imageOffset":17840,"symbol":"_dispatch_once_callout","symbolLocation":32,"imageIndex":7},{"imageOffset":70836,"imageIndex":6},{"imageOffset":450612,"imageIndex":2},{"imageOffset":449720,"imageIndex":2},{"imageOffset":111076,"symbol":"_dispatch_client_callout","symbolLocation":16,"imageIndex":7},{"imageOffset":17840,"symbol":"_dispatch_once_callout","symbolLocation":32,"imageIndex":7},{"imageOffset":4213252,"imageIndex":2},{"imageOffset":893168,"symbol":"StateObject.Box.update(property:phase:)","symbolLocation":468,"imageIndex":8},{"imageOffset":151284,"symbol":"static BoxVTable.update(elt:property:phase:)","symbolLocation":384,"imageIndex":8},{"imageOffset":152004,"symbol":"_DynamicPropertyBuffer.update(container:phase:)","symbolLocation":144,"imageIndex":8},{"imageOffset":150816,"symbol":"closure #1 in closure #1 in DynamicBody.updateValue()","symbolLocation":304,"imageIndex":8},{"imageOffset":150892,"symbol":"partial apply for closure #1 in closure #1 in DynamicBody.updateValue()","symbolLocation":32,"imageIndex":8},{"imageOffset":50992,"symbol":"withUnsafeMutablePointer<A, B, C>(to:_:)","symbolLocation":160,"imageIndex":8},{"imageOffset":149520,"symbol":"closure #1 in DynamicBody.updateValue()","symbolLocation":476,"imageIndex":8},{"imageOffset":148004,"symbol":"DynamicBody.updateValue()","symbolLocation":1220,"imageIndex":8},{"imageOffset":5242832,"symbol":"partial apply for implicit closure #1 in closure #1 in closure #1 in Attribute.init<A>(_:)","symbolLocation":32,"imageIndex":8},{"imageOffset":51476,"symbol":"AG::Graph::UpdateStack::update()","symbolLocation":496,"imageIndex":9},{"imageOffset":50476,"symbol":"AG::Graph::update_attribute(AG::data::ptr<AG::Node>, unsigned int)","symbolLocation":352,"imageIndex":9},{"imageOffset":48744,"symbol":"AG::Graph::input_value_ref_slow(AG::data::ptr<AG::Node>, AG::AttributeID, unsigned int, unsigned int, AGSwiftMetadata const*, unsigned char&, long)","symbolLocation":680,"imageIndex":9},{"imageOffset":25256,"symbol":"AGGraphGetValue","symbolLocation":232,"imageIndex":9},{"imageOffset":143528,"symbol":"StaticBody.container.getter","symbolLocation":84,"imageIndex":8},{"imageOffset":143280,"symbol":"closure #1 in StaticBody.updateValue()","symbolLocation":436,"imageIndex":8},{"imageOffset":141172,"symbol":"StaticBody.updateValue()","symbolLocation":836,"imageIndex":8},{"imageOffset":5242832,"symbol":"partial apply for implicit closure #1 in closure #1 in closure #1 in Attribute.init<A>(_:)","symbolLocation":32,"imageIndex":8},{"imageOffset":51476,"symbol":"AG::Graph::UpdateStack::update()","symbolLocation":496,"imageIndex":9},{"imageOffset":50476,"symbol":"AG::Graph::update_attribute(AG::data::ptr<AG::Node>, unsigned int)","symbolLocation":352,"imageIndex":9},{"imageOffset":48744,"symbol":"AG::Graph::input_value_ref_slow(AG::data::ptr<AG::Node>, AG::AttributeID, unsigned int, unsigned int, AGSwiftMetadata const*, unsigned char&, long)","symbolLocation":680,"imageIndex":9},{"imageOffset":25256,"symbol":"AGGraphGetValue","symbolLocation":232,"imageIndex":9},{"imageOffset":2316692,"symbol":"MakeBody.value.getter","symbolLocation":156,"imageIndex":10},{"imageOffset":7991468,"symbol":"implicit closure #1 in closure #1 in closure #1 in Attribute.init<A>(_:)","symbolLocation":324,"imageIndex":8},{"imageOffset":51476,"symbol":"AG::Graph::UpdateStack::update()","symbolLocation":496,"imageIndex":9},{"imageOffset":50476,"symbol":"AG::Graph::update_attribute(AG::data::ptr<AG::Node>, unsigned int)","symbolLocation":352,"imageIndex":9},{"imageOffset":48744,"symbol":"AG::Graph::input_value_ref_slow(AG::data::ptr<AG::Node>, AG::AttributeID, unsigned int, unsigned int, AGSwiftMetadata const*, unsigned char&, long)","symbolLocation":680,"imageIndex":9},{"imageOffset":53548,"symbol":"AGGraphGetInputValue","symbolLocation":252,"imageIndex":9},{"imageOffset":472056,"symbol":"StackLayout.makeChildren()","symbolLocation":972,"imageIndex":8},{"imageOffset":554472,"symbol":"specialized HVStack.updateCache(_:subviews:)","symbolLocation":256,"imageIndex":8},{"imageOffset":554148,"symbol":"specialized ViewLayoutEngine.update(layout:context:children:)","symbolLocation":576,"imageIndex":8},{"imageOffset":553552,"symbol":"partial apply for specialized closure #1 in Layout.updateLayoutComputer<A>(rule:layoutContext:children:)","symbolLocation":56,"imageIndex":8},{"imageOffset":553352,"symbol":"<deduplicated_symbol>","symbolLocation":28,"imageIndex":8},{"imageOffset":553312,"symbol":"<deduplicated_symbol>","symbolLocation":28,"imageIndex":8},{"imageOffset":553268,"symbol":"partial apply for closure #1 in LayoutEngineBox.mutateEngine<A, B>(as:do:)","symbolLocation":32,"imageIndex":8},{"imageOffset":50992,"symbol":"withUnsafeMutablePointer<A, B, C>(to:_:)","symbolLocation":160,"imageIndex":8},{"imageOffset":553136,"symbol":"LayoutEngineBox.mutateEngine<A, B>(as:do:)","symbolLocation":208,"imageIndex":8},{"imageOffset":10237948,"symbol":"<deduplicated_symbol>","symbolLocation":400,"imageIndex":8},{"imageOffset":402448,"symbol":"specialized StatefulRule<>.updateLayoutComputer<A>(layout:environment:attributes:)","symbolLocation":244,"imageIndex":8},{"imageOffset":402148,"symbol":"specialized DynamicLayoutComputer.updateValue()","symbolLocation":288,"imageIndex":8},{"imageOffset":10357844,"symbol":"specialized implicit closure #1 in closure #1 in closure #1 in Attribute.init<A>(_:)","symbolLocation":96,"imageIndex":8},{"imageOffset":51476,"symbol":"AG::Graph::UpdateStack::update()","symbolLocation":496,"imageIndex":9},{"imageOffset":50476,"symbol":"AG::Graph::update_attribute(AG::data::ptr<AG::Node>, unsigned int)","symbolLocation":352,"imageIndex":9},{"imageOffset":48744,"symbol":"AG::Graph::input_value_ref_slow(AG::data::ptr<AG::Node>, AG::AttributeID, unsigned int, unsigned int, AGSwiftMetadata const*, unsigned char&, long)","symbolLocation":680,"imageIndex":9},{"imageOffset":25256,"symbol":"AGGraphGetValue","symbolLocation":232,"imageIndex":9},{"imageOffset":558304,"symbol":"DynamicLayoutViewChildGeometry.updateValue()","symbolLocation":260,"imageIndex":8},{"imageOffset":10353768,"symbol":"specialized implicit closure #1 in closure #1 in closure #1 in Attribute.init<A>(_:)","symbolLocation":24,"imageIndex":8},{"imageOffset":51476,"symbol":"AG::Graph::UpdateStack::update()","symbolLocation":496,"imageIndex":9},{"imageOffset":50476,"symbol":"AG::Graph::update_attribute(AG::data::ptr<AG::Node>, unsigned int)","symbolLocation":352,"imageIndex":9},{"imageOffset":48744,"symbol":"AG::Graph::input_value_ref_slow(AG::data::ptr<AG::Node>, AG::AttributeID, unsigned int, unsigned int, AGSwiftMetadata const*, unsigned char&, long)","symbolLocation":680,"imageIndex":9},{"imageOffset":25256,"symbol":"AGGraphGetValue","symbolLocation":232,"imageIndex":9},{"imageOffset":497492,"symbol":"AnimatableFrameAttribute.updateValue()","symbolLocation":68,"imageIndex":8},{"imageOffset":10346204,"symbol":"specialized implicit closure #1 in closure #1 in closure #1 in Attribute.init<A>(_:)","symbolLocation":24,"imageIndex":8},{"imageOffset":51476,"symbol":"AG::Graph::UpdateStack::update()","symbolLocation":496,"imageIndex":9},{"imageOffset":59212,"symbol":"AG::Subgraph::update(unsigned int)","symbolLocation":972,"imageIndex":9},{"imageOffset":544832,"symbol":"specialized GraphHost.runTransaction(_:do:id:)","symbolLocation":368,"imageIndex":8},{"imageOffset":120732,"symbol":"GraphHost.flushTransactions()","symbolLocation":180,"imageIndex":8},{"imageOffset":117720,"symbol":"closure #1 in ViewGraphRootValueUpdater.render(interval:updateDisplayList:targetTimestamp:)","symbolLocation":880,"imageIndex":8},{"imageOffset":116760,"symbol":"ViewGraphRootValueUpdater.render(interval:updateDisplayList:targetTimestamp:)","symbolLocation":584,"imageIndex":8},{"imageOffset":1977604,"imageIndex":11},{"imageOffset":125884,"symbol":"_UIHostingView.layoutSubviews()","symbolLocation":116,"imageIndex":10},{"imageOffset":125732,"symbol":"@objc _UIHostingView.layoutSubviews()","symbolLocation":36,"imageIndex":10},{"imageOffset":295328,"imageIndex":11},{"imageOffset":297708,"imageIndex":11},{"imageOffset":290976,"symbol":"-[UIView(CALayerDelegate) layoutSublayersOfLayer:]","symbolLocation":2684,"imageIndex":11},{"imageOffset":2873508,"symbol":"CA::Layer::perform_update_(CA::Layer*, CALayer*, unsigned int, CA::LayerUpdateReason, CA::Transaction*)","symbolLocation":460,"imageIndex":12},{"imageOffset":2872308,"symbol":"CA::Layer::update_if_needed_(CA::Transaction*, CA::LayerUpdateReason)","symbolLocation":664,"imageIndex":12},{"imageOffset":718848,"symbol":"CA::Layer::layout_and_display_if_needed(CA::Transaction*)","symbolLocation":180,"imageIndex":12},{"imageOffset":450968,"symbol":"CA::Context::commit_transaction(CA::Transaction*, double, double*)","symbolLocation":560,"imageIndex":12},{"imageOffset":632096,"symbol":"CA::Transaction::commit()","symbolLocation":620,"imageIndex":12},{"imageOffset":2385148,"symbol":"__34-[UIApplication _firstCommitBlock]_block_invoke_2","symbolLocation":36,"imageIndex":11},{"imageOffset":187084,"symbol":"__CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__","symbolLocation":28,"imageIndex":13},{"imageOffset":186264,"symbol":"__CFRunLoopDoBlocks","symbolLocation":396,"imageIndex":13},{"imageOffset":192956,"symbol":"__CFRunLoopRun","symbolLocation":848,"imageIndex":13},{"imageOffset":189772,"symbol":"_CFRunLoopRunSpecificWithOptions","symbolLocation":532,"imageIndex":13},{"imageOffset":5272,"symbol":"GSEventRunModal","symbolLocation":120,"imageIndex":14},{"imageOffset":1185392,"symbol":"-[UIApplication _run]","symbolLocation":796,"imageIndex":11},{"imageOffset":573784,"symbol":"UIApplicationMain","symbolLocation":332,"imageIndex":11},{"imageOffset":198000,"symbol":"closure #1 in KitRendererCommon(_:)","symbolLocation":168,"imageIndex":10},{"imageOffset":184564,"symbol":"runApp<A>(_:)","symbolLocation":112,"imageIndex":10},{"imageOffset":183368,"symbol":"static App.main()","symbolLocation":172,"imageIndex":10},{"imageOffset":4665864,"imageIndex":2},{"imageOffset":57424,"symbol":"LiveContainerMain","symbolLocation":8420,"imageIndex":1},{"imageOffset":19484,"symbol":"start","symbolLocation":6928,"imageIndex":15}],"id":2009277,"recursionInfoArray":[{"hottestElided":36,"coldestElided":133,"depth":22,"keyFrame":{"imageOffset":51476,"symbol":"AG::Graph::UpdateStack::update()","symbolLocation":496,"imageIndex":9}}],"originalLength":194,"triggered":true,"threadState":{"x":[{"value":4522484497},{"value":0},{"value":1},{"value":0},{"value":4525195712},{"value":15},{"value":18446744072631617535},{"value":18446726482597246976},{"value":8482865152,"symbolLocation":0,"symbol":"get_file.ux"},{"value":7625345733139235060},{"value":5},{"value":63},{"value":2340387},{"value":3458764518346145920},{"value":72057602566829153,"symbolLocation":72057594037927937,"symbol":"OBJC_CLASS_$___NSCFString"},{"value":8528901216,"symbolLocation":0,"symbol":"OBJC_CLASS_$___NSCFString"},{"value":6956518692,"symbolLocation":0,"symbol":"_os_crash"},{"value":6759993880,"symbolLocation":0,"symbol":"-[__NSCFString UTF8String]"},{"value":0},{"value":8567831840},{"value":8567931008},{"value":4465120000},{"value":4524364768},{"value":4524387584},{"value":8567930976},{"value":0},{"value":0},{"value":6088942432},{"value":6088942448}],"flavor":"ARM_THREAD_STATE64","lr":{"value":6849926336},"cpsr":{"value":1610616832},"fp":{"value":6088942224},"sp":{"value":6088941808},"esr":{"value":4060086273,"description":"(Breakpoint) brk 1"},"pc":{"value":6849926336,"matchesCrashFrame":1},"far":{"value":0}},"queue":"com.apple.main-thread"},{"id":2009279,"frames":[],"threadState":{"x":[{"value":6089551872},{"value":6403},{"value":6089015296},{"value":0},{"value":409604},{"value":18446744073709551615},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0}],"flavor":"ARM_THREAD_STATE64","lr":{"value":0},"cpsr":{"value":4096},"fp":{"value":0},"sp":{"value":6089551872},"esr":{"value":1442840704,"description":"(Syscall)"},"pc":{"value":8363174072},"far":{"value":0}}},{"id":2009281,"frames":[],"threadState":{"x":[{"value":6090125312},{"value":8963},{"value":6089588736},{"value":0},{"value":409604},{"value":18446744073709551615},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0}],"flavor":"ARM_THREAD_STATE64","lr":{"value":0},"cpsr":{"value":4096},"fp":{"value":0},"sp":{"value":6090125312},"esr":{"value":1442840704,"description":"(Syscall)"},"pc":{"value":8363174072},"far":{"value":0}}},{"id":2009283,"frames":[],"threadState":{"x":[{"value":6090698752},{"value":10755},{"value":6090162176},{"value":0},{"value":409604},{"value":18446744073709551615},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0}],"flavor":"ARM_THREAD_STATE64","lr":{"value":0},"cpsr":{"value":4096},"fp":{"value":0},"sp":{"value":6090698752},"esr":{"value":1442840704,"description":"(Syscall)"},"pc":{"value":8363174072},"far":{"value":0}}},{"id":2009289,"frames":[],"threadState":{"x":[{"value":6091272192},{"value":15875},{"value":6090735616},{"value":0},{"value":409604},{"value":18446744073709551615},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0}],"flavor":"ARM_THREAD_STATE64","lr":{"value":0},"cpsr":{"value":4096},"fp":{"value":0},"sp":{"value":6091272192},"esr":{"value":1442840704,"description":"(Syscall)"},"pc":{"value":8363174072},"far":{"value":0}}},{"id":2009290,"frames":[],"threadState":{"x":[{"value":6091845632},{"value":19731},{"value":6091309056},{"value":0},{"value":409604},{"value":18446744073709551615},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0}],"flavor":"ARM_THREAD_STATE64","lr":{"value":0},"cpsr":{"value":4096},"fp":{"value":0},"sp":{"value":6091845632},"esr":{"value":1442840704,"description":"(Syscall)"},"pc":{"value":8363174072},"far":{"value":0}}},{"id":2009291,"name":"com.apple.uikit.eventfetch-thread","threadState":{"x":[{"value":268451845},{"value":21592279046},{"value":8589934592,"symbolLocation":8,"symbol":"_OBJC_METACLASS_RO_$_HMHomeFetchLightProfileSettingsResult"},{"value":72580652335104},{"value":2162692},{"value":72580652335104},{"value":2},{"value":4294967295},{"value":0},{"value":0},{"value":2},{"value":0},{"value":0},{"value":16899},{"value":4387212240},{"value":4463607808},{"value":18446744073709551569},{"value":18446744072367376383},{"value":0},{"value":4294967295},{"value":2},{"value":72580652335104},{"value":2162692},{"value":72580652335104},{"value":21592279046},{"value":6092414344},{"value":8589934592,"symbolLocation":8,"symbol":"_OBJC_METACLASS_RO_$_HMHomeFetchLightProfileSettingsResult"},{"value":18446744073709550527},{"value":11008376832,"symbolLocation":0,"symbol":"_libkernel_string_functions"}],"flavor":"ARM_THREAD_STATE64","lr":{"value":9700754188},"cpsr":{"value":4096},"fp":{"value":6092414192},"sp":{"value":6092414112},"esr":{"value":1442840704,"description":"(Syscall)"},"pc":{"value":9700740308},"far":{"value":0}},"frames":[{"imageOffset":3284,"symbol":"mach_msg2_trap","symbolLocation":8,"imageIndex":18},{"imageOffset":17164,"symbol":"mach_msg2_internal","symbolLocation":76,"imageIndex":18},{"imageOffset":16940,"symbol":"mach_msg_overwrite","symbolLocation":424,"imageIndex":18},{"imageOffset":16504,"symbol":"mach_msg","symbolLocation":24,"imageIndex":18},{"imageOffset":414532,"symbol":"__CFRunLoopServiceMachPort","symbolLocation":160,"imageIndex":13},{"imageOffset":193296,"symbol":"__CFRunLoopRun","symbolLocation":1188,"imageIndex":13},{"imageOffset":189772,"symbol":"_CFRunLoopRunSpecificWithOptions","symbolLocation":532,"imageIndex":13},{"imageOffset":44272,"symbol":"-[NSRunLoop(NSRunLoop) runMode:beforeDate:]","symbolLocation":212,"imageIndex":19},{"imageOffset":43992,"symbol":"-[NSRunLoop(NSRunLoop) runUntilDate:]","symbolLocation":64,"imageIndex":19},{"imageOffset":945836,"symbol":"-[UIEventFetcher threadMain]","symbolLocation":420,"imageIndex":11},{"imageOffset":583940,"symbol":"__NSThread__start__","symbolLocation":732,"imageIndex":19},{"imageOffset":17464,"symbol":"_pthread_start","symbolLocation":136,"imageIndex":20},{"imageOffset":2252,"symbol":"thread_start","symbolLocation":8,"imageIndex":20}]},{"id":2009292,"frames":[],"threadState":{"x":[{"value":6092992512},{"value":16395},{"value":6092455936},{"value":0},{"value":409604},{"value":18446744073709551615},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0}],"flavor":"ARM_THREAD_STATE64","lr":{"value":0},"cpsr":{"value":4096},"fp":{"value":0},"sp":{"value":6092992512},"esr":{"value":1442840704,"description":"(Syscall)"},"pc":{"value":8363174072},"far":{"value":0}}},{"id":2009293,"frames":[],"threadState":{"x":[{"value":6093565952},{"value":18179},{"value":6093029376},{"value":0},{"value":409604},{"value":18446744073709551615},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0}],"flavor":"ARM_THREAD_STATE64","lr":{"value":0},"cpsr":{"value":4096},"fp":{"value":0},"sp":{"value":6093565952},"esr":{"value":1442840704,"description":"(Syscall)"},"pc":{"value":8363174072},"far":{"value":0}}},{"id":2009294,"frames":[],"threadState":{"x":[{"value":6094139392},{"value":18947},{"value":6093602816},{"value":0},{"value":409604},{"value":18446744073709551615},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0}],"flavor":"ARM_THREAD_STATE64","lr":{"value":0},"cpsr":{"value":4096},"fp":{"value":0},"sp":{"value":6094139392},"esr":{"value":1442840704,"description":"(Syscall)"},"pc":{"value":8363174072},"far":{"value":0}}}],
  "usedImages" : [
  {
    "source" : "P",
    "arch" : "arm64",
    "base" : 4377886720,
    "size" : 32768,
    "uuid" : "e01d22cc-3aa2-357f-81cd-3791065727e5",
    "path" : "\/private\/var\/containers\/Bundle\/Application\/4B4F562A-BAE8-429F-87AC-D3003E51C6EA\/App.app\/LiveContainer",
    "name" : "LiveContainer"
  },
  {
    "source" : "P",
    "arch" : "arm64",
    "base" : 4378296320,
    "size" : 98304,
    "uuid" : "2cd08a76-a0f7-3867-8dbf-587909d198dc",
    "path" : "\/private\/var\/containers\/Bundle\/Application\/4B4F562A-BAE8-429F-87AC-D3003E51C6EA\/App.app\/Frameworks\/LiveContainerShared.framework\/LiveContainerShared",
    "name" : "LiveContainerShared"
  },
  {
    "source" : "P",
    "arch" : "arm64",
    "base" : 4513841152,
    "size" : 6389760,
    "uuid" : "6ef609c6-cdc3-33ad-9e04-35d36e1d881c",
    "path" : "\/private\/var\/mobile\/Containers\/Data\/Application\/C214B7D5-33C6-4554-9005-63CD567C1107\/Documents\/Applications\/ym.si.clashdash.app\/Clash Dash",
    "name" : "Clash Dash"
  },
  {
    "source" : "P",
    "arch" : "arm64",
    "base" : 4378918912,
    "size" : 65536,
    "uuid" : "c228b054-a317-37ec-a439-afd31496967e",
    "path" : "\/private\/var\/mobile\/Containers\/Data\/Application\/C214B7D5-33C6-4554-9005-63CD567C1107\/Documents\/Applications\/ym.si.clashdash.app\/Frameworks\/Shared.framework\/Shared",
    "name" : "Shared"
  },
  {
    "source" : "P",
    "arch" : "arm64",
    "base" : 4379082752,
    "size" : 65536,
    "uuid" : "243f2cf3-87ce-37ec-a98d-4e94fcd46601",
    "path" : "\/private\/var\/containers\/Bundle\/Application\/4B4F562A-BAE8-429F-87AC-D3003E51C6EA\/App.app\/Frameworks\/TweakLoader.dylib",
    "name" : "TweakLoader.dylib"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 4380278784,
    "size" : 49152,
    "uuid" : "6893bf2a-db4b-33d9-875d-eea7cb8f8060",
    "path" : "\/private\/preboot\/Cryptexes\/OS\/usr\/lib\/libobjc-trampolines.dylib",
    "name" : "libobjc-trampolines.dylib"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6849880064,
    "size" : 4228160,
    "uuid" : "8bb783df-e71b-3961-bfc0-e9808d1326a1",
    "path" : "\/System\/Library\/Frameworks\/CloudKit.framework\/CloudKit",
    "name" : "CloudKit"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 7744716800,
    "size" : 288256,
    "uuid" : "955b1789-d542-3497-b46d-bd6be85f91a2",
    "path" : "\/usr\/lib\/system\/libdispatch.dylib",
    "name" : "libdispatch.dylib"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6931185664,
    "size" : 15714240,
    "uuid" : "e47d2d7d-0a0a-3bfd-ab6a-3e86a7cd0b23",
    "path" : "\/System\/Library\/Frameworks\/SwiftUICore.framework\/SwiftUICore",
    "name" : "SwiftUICore"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 7623950336,
    "size" : 283040,
    "uuid" : "feb88855-6110-3eeb-9ad0-198805fd4fe8",
    "path" : "\/System\/Library\/PrivateFrameworks\/AttributeGraph.framework\/AttributeGraph",
    "name" : "AttributeGraph"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6911422464,
    "size" : 19446176,
    "uuid" : "fd601f35-1f63-3a01-8d2c-9c3d01a79a24",
    "path" : "\/System\/Library\/Frameworks\/SwiftUI.framework\/SwiftUI",
    "name" : "SwiftUI"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6856589312,
    "size" : 39073344,
    "uuid" : "26334227-f558-3da7-985d-326a0c894dd4",
    "path" : "\/System\/Library\/PrivateFrameworks\/UIKitCore.framework\/UIKitCore",
    "name" : "UIKitCore"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6770257920,
    "size" : 4132544,
    "uuid" : "a30444a6-06c1-3996-b839-0c172e74ed39",
    "path" : "\/System\/Library\/Frameworks\/QuartzCore.framework\/QuartzCore",
    "name" : "QuartzCore"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6759854080,
    "size" : 5884352,
    "uuid" : "5565cad9-4941-32ac-8b10-7d3233c74151",
    "path" : "\/System\/Library\/Frameworks\/CoreFoundation.framework\/CoreFoundation",
    "name" : "CoreFoundation"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 9540616192,
    "size" : 34752,
    "uuid" : "7915658c-7728-3149-a524-2164c163f3d2",
    "path" : "\/System\/Library\/PrivateFrameworks\/GraphicsServices.framework\/GraphicsServices",
    "name" : "GraphicsServices"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6705549312,
    "size" : 676992,
    "uuid" : "0ba28ce2-8718-3cb3-bef4-6dd44464ebe2",
    "path" : "\/usr\/lib\/dyld",
    "name" : "dyld"
  },
  {
    "size" : 0,
    "source" : "A",
    "base" : 0,
    "uuid" : "00000000-0000-0000-0000-000000000000"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6956449792,
    "size" : 521728,
    "uuid" : "ca7f1aef-8c1f-33a2-b1cc-52d9ab644bea",
    "path" : "\/usr\/lib\/system\/libsystem_c.dylib",
    "name" : "libsystem_c.dylib"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 9700737024,
    "size" : 244512,
    "uuid" : "a11bf433-17ab-3f01-88bc-54c467ce6287",
    "path" : "\/usr\/lib\/system\/libsystem_kernel.dylib",
    "name" : "libsystem_kernel.dylib"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6712213504,
    "size" : 15244320,
    "uuid" : "1689fea5-1780-3efe-8f31-933d4db24ec4",
    "path" : "\/System\/Library\/Frameworks\/Foundation.framework\/Foundation",
    "name" : "Foundation"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 8363171840,
    "size" : 50416,
    "uuid" : "46b95807-f752-3dc2-a1ba-6290e8d7fe38",
    "path" : "\/usr\/lib\/system\/libsystem_pthread.dylib",
    "name" : "libsystem_pthread.dylib"
  }
],
  "sharedCache" : {
  "base" : 6704381952,
  "size" : 5379997696,
  "uuid" : "957de89b-bb81-351d-9b44-28bbd8255abb"
},
  "vmSummary" : "ReadOnly portion of Libraries: Total=1.7G resident=0K(0%) swapped_out_or_unallocated=1.7G(100%)\nWritable regions: Total=100.8M written=593K(1%) resident=593K(1%) swapped_out=0K(0%) unallocated=100.2M(99%)\n\n                                VIRTUAL   REGION \nREGION TYPE                        SIZE    COUNT (non-coalesced) \n===========                     =======  ======= \nActivity Tracing                   256K        1 \nAttributeGraph Data               1024K        1 \nColorSync                           16K        1 \nCoreAnimation                       48K        3 \nFoundation                          16K        1 \nKernel Alloc Once                   32K        1 \nMALLOC                            28.8M       14 \nMALLOC guard page                 3904K        4 \nMemory Tag 22                     64.0M        1 \nSTACK GUARD                        160K       10 \nStack                             5904K       10 \nVM_ALLOCATE                        144K        1 \n__AUTH                            8336K      716 \n__AUTH_CONST                     104.7M     1133 \n__CTF                               824        1 \n__DATA                            44.3M     1078 \n__DATA_CONST                      36.1M     1143 \n__DATA_DIRTY                      9884K      998 \n__FONT_DATA                        2352        1 \n__LINKEDIT                       179.8M        7 \n__OBJC_RO                         84.8M        1 \n__OBJC_RW                         3182K        1 \n__TEXT                             1.6G     1158 \n__TPRO_CONST                       128K        2 \nmapped file                      401.6M       26 \npage table in kernel               593K        1 \nshared memory                       80K        4 \n===========                     =======  ======= \nTOTAL                              2.5G     6318 \n",
  "legacyInfo" : {
  "threadTriggered" : {
    "queue" : "com.apple.main-thread"
  }
},
  "logWritingSignature" : "9a874c3133a51e44b647b1c5460dca478bcf6734",
  "bug_type" : "309",
  "roots_installed" : 0,
  "trmStatus" : 1,
  "sandboxProfileName" : "container",
  "trialInfo" : {
  "rollouts" : [
    {
      "rolloutId" : "601074e4af9bef000c169ea8",
      "factorPackIds" : [
        "6a7f2e617f3fa271b663de66"
      ],
      "deploymentId" : 240005051
    },
    {
      "rolloutId" : "6297d96be2c9387df974efa4",
      "factorPackIds" : [
        "66cf8b4c28f6565e7ca0b4b2"
      ],
      "deploymentId" : 240000032
    }
  ],
  "experiments" : [
    {
      "treatmentId" : "d5c127b8-b13e-42a1-acf5-c483124a1bb5",
      "experimentId" : "66b1602abe27b2208fd291ba",
      "deploymentId" : 400000022
    },
    {
      "treatmentId" : "79ab2405-38c9-4893-8257-dd75d3536a8e",
      "experimentId" : "6a39873949f37f57cc6838ec",
      "deploymentId" : 400000005
    }
  ]
}
}
```